### PR TITLE
Fixed possible timeouts in housekeeping

### DIFF
--- a/server/gokb/grails-app/services/org/gokb/CleanupService.groovy
+++ b/server/gokb/grails-app/services/org/gokb/CleanupService.groovy
@@ -83,7 +83,7 @@ class CleanupService {
 
     // Use Groovy with() method to invoke multiple methods
     // on the sqlQuery object.
-      final results = sqlQuery.with {
+    final results = sqlQuery.with {
  
         // Set value for parameter startId.
       setLong('rdvId', id_combo_type_id)
@@ -128,19 +128,26 @@ class CleanupService {
         log.debug "Matched number of deletions and projected number, delete..."
         
         query = 'DELETE FROM Combo c WHERE c.combo_id IN (:delete_ids)'
-        
-        // Create native SQL query.
-        sqlQuery = session.createSQLQuery(query)
-        def dres = sqlQuery.with {
-          
-           // Set value for parameter startId.
-           setParameterList('delete_ids', to_delete)
-           
-           // Get all results.
-           executeUpdate()
-         }
-    
-         log.debug "Delete query returned ${dres} duplicated identifier instances removed."
+
+        while(to_delete.size() > 0){
+          def to_delete_size = to_delete.size();
+          def qrySize = (to_delete.size() > 50) ? 50 : to_delete.size();
+          log.debug "${to_delete_size} identifiers remaining."
+          def to_delete_part = to_delete.take(qrySize);
+          to_delete = to_delete.drop(qrySize);
+
+          // Create native SQL query.
+          sqlQuery = session.createSQLQuery(query)
+          def dres = sqlQuery.with {
+
+            // Set value for parameter startId.
+            setParameterList('delete_ids', to_delete_part)
+
+            // Get all results.
+            executeUpdate()
+          }
+          log.debug "Delete query returned ${dres} duplicated identifier instances removed."
+        }
       } else {
         log.debug "No duplicates to delete..."
       }


### PR DESCRIPTION
While performing a housekeeping for about 60k identifiers, the database update failed because of a time-out. This may be due to performance problems of setParameterList in combination with big lists, as mentioned in [this post](https://hibernate.atlassian.net/browse/HHH-766). To fix this, the array can be processed in chunks.